### PR TITLE
Fix: fail the CI if flake8 fails

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 echo "Running flake8 ..."
 flake8 dorpsgek_runner
 


### PR DESCRIPTION
Without 'set -e', an non-zero exit code from flake8 is simply
ignored and test.sh continues. With 'set -e' it abort on the
first non-zero exit code.